### PR TITLE
Fix typo in stopwordslangs.Rd

### DIFF
--- a/man/stopwordslangs.Rd
+++ b/man/stopwordslangs.Rd
@@ -9,7 +9,7 @@
 stopwordslangs
 }
 \description{
-This data comes form a group of Twitter searches conducted at
+This data comes from a group of Twitter searches conducted at
 several times during the calendar year of 2017. The data are
 commonly observed words associated with 10 different languages,
 including \code{c("ar", "en", "es", "fr", "in", "ja", "pt", "ru",


### PR DESCRIPTION
Follow up from this [post](https://github.com/mkearney/rtweet/issues/172). Modified `stopwordslangs.Rd` to fix typo (form to from).

> This data comes **form** a group of Twitter searches conducted at several times during the calendar year of 2017. The data are commonly observed words associated with 10 different languages, including c("ar", "en", "es", "fr", "in", "ja", "pt", "ru", "tr", "und"). Variables include "word" (potential stop words), "lang" (two or three word code), and "p" (probability value associated with frequency position along a normal distribution with higher values meaning the word occurs more frequently and lower values meaning the words occur less frequently).